### PR TITLE
Use async_manual_reset_event instead of timer

### DIFF
--- a/unifex_bench/main.cpp
+++ b/unifex_bench/main.cpp
@@ -1,33 +1,40 @@
 #include <unifex/sync_wait.hpp>
 #include <unifex/task.hpp>
-#include <unifex/timed_single_thread_context.hpp>
+#include <unifex/just.hpp>
+#include <unifex/then.hpp>
+#include <unifex/when_all.hpp>
 #include <unifex/when_all_range.hpp>
+#include <unifex/async_scope.hpp>
+#include <unifex/async_manual_reset_event.hpp>
 
 #include <chrono>
 #include <cstdio>
+#include <iostream>
 #include <cstdlib>
 #include <ranges>
 #include <vector>
 
-unifex::timed_single_thread_context TIMER;
-
-auto async_sleep(auto s) { return unifex::schedule_after(TIMER.get_scheduler(), s); }
-
 int main(int argc, char **argv) {
     if (argc < 2) {
         fprintf(stderr,
-                      "Please specify the number of tasks\n"
-                      "example: %s 10000\n",
-                      argv[0]);
+                "Please specify the number of tasks\n"
+                "example: %s 10000\n",
+                argv[0]);
         return EXIT_FAILURE;
     }
 
     std::vector<unifex::task<void>> tasks;
+    unifex::async_manual_reset_event evt;
+    int counter = 0;
 
     for (auto i : std::views::iota(0, std::stoi(argv[1]))) {
         tasks.push_back(
-            []() -> unifex::task<void> { co_await async_sleep(std::chrono::seconds(10)); }());
+                [](int& counter, auto& evt) -> unifex::task<void> { ++counter; co_await evt.async_wait(); --counter; }(counter, evt));
     }
-     
-    unifex::sync_wait(unifex::when_all_range(std::move(tasks)));
+
+    unifex::sync_wait(unifex::when_all(
+        unifex::when_all_range(std::move(tasks)),
+        unifex::just() | unifex::then([&] { std::cout << "counter=" << counter << "\n"; evt.set(); })
+    ));
+    return 0;
 }


### PR DESCRIPTION
The benchmark hangs when run with 1 million tasks. I haven't looked into it, but perhaps there is an inefficient implementation of the timer in unifex.

As a POC, I reimplemented the unifex benchmark to spawn N tasks and have them wait until all N are created before completing the program. I did not change the other benchmarks.